### PR TITLE
Publish config to S3

### DIFF
--- a/resources/scripts/publish_config.py
+++ b/resources/scripts/publish_config.py
@@ -1,0 +1,10 @@
+import boto3
+import io
+import sys
+
+s3 = boto3.client('s3')
+
+network_id = "testnet"
+
+f = io.BytesIO(bytes(' '.join(sys.argv), encoding="ascii"))
+s3.upload_fileobj(f, "config.spacemesh.io", network_id)

--- a/vars/runMiners.groovy
+++ b/vars/runMiners.groovy
@@ -105,6 +105,7 @@ def call(String aws_region) {
 
             worker_ports = random_ports(miner_count)
             worker_ports.sort()
+            sh "python3 publish_config ${extra_params}"
           }
           echo "Number of miners: ${miner_count}"
           echo "Miner pool ID: ${pool_id}"


### PR DESCRIPTION
Missing:
- [ ] `pip3 install boto3` on the Jenkins machine (should this be added to the code somewhere or are we running things like this manually on the machine?)
- [ ] The jenkins machine should be granted write access to the `config.spacemesh.io` bucket (again, not sure if this is done from code, or directly in AWS)

closes https://github.com/spacemeshos/go-spacemesh/issues/1638